### PR TITLE
Construct ExceptHandler nodes with location information

### DIFF
--- a/crates/py_ast/src/to_ast/stmt.rs
+++ b/crates/py_ast/src/to_ast/stmt.rs
@@ -261,11 +261,14 @@ impl_to_ast!(StmtRaise, call "Raise" with fields [
 impl ToAst for ExceptHandler {
     fn to_ast(&self, module: &AstModule) -> PyResult {
         match self {
-            ExceptHandler::ExceptHandler(node) => module.attr("ExceptHandler")?.callk([
-                ("type", node.type_.to_ast(module)?),
-                ("name", node.name.to_ast(module)?),
-                ("body", node.body.to_ast(module)?),
-            ]),
+            ExceptHandler::ExceptHandler(node) => module.attr("ExceptHandler")?.call(
+                node.range,
+                [
+                    ("type", node.type_.to_ast(module)?),
+                    ("name", node.name.to_ast(module)?),
+                    ("body", node.body.to_ast(module)?),
+                ],
+            ),
         }
     }
 }


### PR DESCRIPTION
Fixes #20.

Currently `ast.ExceptHandler` nodes are being constructed via `AstModule::callk()` directly, with only the `type`, `name` and `body` fields specified. This PR changes that to use `call()` instead, and passes the node's `TextRange` so that `lineno`, `end_lineno`, `col_offset`, and `end_col_offset` get set.

I didn't bother adding a test case because this would normally be caught anyway by `tests/test_py_syntax.py`. But the AST dump that's used for comparison in that test is temporarily being generated without location information because of a different bug. It wouldn't be hard to add another test for this in particular, it just seems redundant with that already in place.